### PR TITLE
Reduced y-axis label size

### DIFF
--- a/server.R
+++ b/server.R
@@ -114,8 +114,8 @@ plot_data_var <- function(data, var, daterange, unit="", display_x_labels=FALSE)
                   panel.grid.major.x = element_blank(),
                   plot.title=element_text(hjust=0.5, size=15, face="bold"),
                   axis.text.x = element_text(size=12, angle=45, hjust=1),
-                  axis.text.y = element_text(size=12),
-                  axis.title.y = element_text(size=13, margin=margin(r=10)),
+                  axis.text.y = element_text(size=10),
+                  axis.title.y = element_text(size=12, margin=margin(r=10)),
                   panel.spacing.y = unit(1.5, "lines")
                  )
             if (!display_x_labels) {


### PR DESCRIPTION
The size of text components on the live website is larger than on my development machine. The original y-axis label size of 13 looked fine on my machine but resulted in overlapping on the live site. I've reduced the text size to 12 to see if this fixes the overlap.